### PR TITLE
style: update mobile sidebarnav items #72

### DIFF
--- a/app/(routes)/(admin)/admin/(root))/layout.tsx
+++ b/app/(routes)/(admin)/admin/(root))/layout.tsx
@@ -21,7 +21,9 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
 
   return (
     <div className="flex min-h-screen flex-col space-y-6">
-      <NavBar user={user} items={adminConfig.mainNav} scroll={false} />
+      <NavBar user={user} items={adminConfig.mainNav} scroll={false}>
+        <DashboardNav items={adminConfig.sidebarNav} />
+      </NavBar>
 
       <div className="container grid flex-1 gap-12 md:grid-cols-[200px_1fr]">
         <aside className="hidden w-[200px] flex-col md:flex">

--- a/app/(routes)/(admin)/admin/(teacher)/teacher/layout.tsx
+++ b/app/(routes)/(admin)/admin/(teacher)/teacher/layout.tsx
@@ -21,7 +21,9 @@ export default async function TeacherLayout({ children }: TeacherLayoutProps) {
 
   return (
     <div className="flex min-h-screen flex-col space-y-6">
-      <NavBar user={user} items={teacherConfig.mainNav} scroll={false} />
+      <NavBar user={user} items={teacherConfig.mainNav} scroll={false}>
+        <DashboardNav items={teacherConfig.sidebarNav} />
+      </NavBar>
 
       <div className="container grid flex-1 gap-12 md:grid-cols-[200px_1fr]">
         <aside className="hidden w-[200px] flex-col md:flex">

--- a/app/(routes)/(dashboard)/layout.tsx
+++ b/app/(routes)/(dashboard)/layout.tsx
@@ -22,7 +22,9 @@ export default async function DashboardLayout({
 
   return (
     <div className="flex min-h-screen flex-col space-y-6">
-      <NavBar user={user} items={dashboardConfig.mainNav} scroll={false} />
+      <NavBar user={user} items={dashboardConfig.mainNav} scroll={false}>
+        <DashboardNav items={dashboardConfig.sidebarNav} />
+      </NavBar>
 
       <div className="container grid flex-1 gap-12 md:grid-cols-[200px_1fr]">
         <aside className="hidden w-[200px] flex-col md:flex">

--- a/app/(routes)/(learn)/learn/(playbook)/layout.tsx
+++ b/app/(routes)/(learn)/learn/(playbook)/layout.tsx
@@ -1,10 +1,12 @@
 import Link from 'next/link';
 
+import { DashboardNav } from '@/app/components/layout/nav';
 import { NavBar } from '@/app/components/layout/navbar';
 import { SiteFooter } from '@/app/components/layout/site-footer';
 import { Icons } from '@/app/components/shared/icons';
 import { Button } from '@/app/components/ui/button';
 import { playbookConfig } from '@/app/config/playbook';
+import { playbooksConfig } from '@/app/config/playbooks';
 import { getCurrentUser } from '@/app/lib/session';
 
 interface PlaybookRootLayoutProps {
@@ -33,7 +35,9 @@ export default async function PlaybookRootLayout({
         user={user}
         items={playbookConfig.mainNav}
         rightElements={rightHeader()}
-      />
+      >
+        <DashboardNav items={playbooksConfig.sidebarNav} />
+      </NavBar>
       <div className="container flex-1">{children}</div>
       <SiteFooter className="border-t" />
     </div>

--- a/app/(routes)/(learn)/learn/(playbooks)/layout.tsx
+++ b/app/(routes)/(learn)/learn/(playbooks)/layout.tsx
@@ -22,7 +22,9 @@ export default async function PlaybooksLayout({
 
   return (
     <div className="flex min-h-screen flex-col space-y-6">
-      <NavBar user={user} items={playbooksConfig.mainNav} scroll={false} />
+      <NavBar user={user} items={playbooksConfig.mainNav} scroll={false}>
+        <DashboardNav items={playbooksConfig.sidebarNav} />
+      </NavBar>
 
       <div className="container grid flex-1 gap-12 md:grid-cols-[200px_1fr]">
         <aside className="hidden w-[200px] flex-col md:flex">

--- a/app/components/layout/main-nav.tsx
+++ b/app/components/layout/main-nav.tsx
@@ -56,7 +56,7 @@ export function MainNav({ items, children }: MainNavProps) {
                 'flex items-center text-lg font-medium transition-colors hover:text-foreground/80 sm:text-sm',
                 pathname.startsWith(item.href)
                   ? 'font-semibold text-brand underline decoration-4 underline-offset-4'
-                  : 'text-foreground/60',
+                  : 'text-muted-foreground',
                 item.disabled && 'cursor-not-allowed opacity-80',
               )}
               target={item.isExternal ? '_blank' : '_self'}

--- a/app/components/layout/mobile-nav.tsx
+++ b/app/components/layout/mobile-nav.tsx
@@ -1,5 +1,8 @@
+'use client';
+
 import * as React from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import { Icons } from '@/app/components/shared/icons';
 import { siteConfig } from '@/app/config/site';
@@ -13,6 +16,7 @@ interface MobileNavProps {
 }
 
 export function MobileNav({ items, children }: MobileNavProps) {
+  const pathname = usePathname();
   useLockBody();
 
   return (
@@ -21,18 +25,21 @@ export function MobileNav({ items, children }: MobileNavProps) {
         'fixed inset-0 top-16 z-50 grid h-[calc(100vh-4rem)] grid-flow-row auto-rows-max overflow-auto p-6 pb-32 shadow-md animate-in slide-in-from-bottom-80 md:hidden',
       )}
     >
-      <div className="relative z-20 grid gap-6 rounded-md bg-popover p-4 text-popover-foreground shadow-md">
+      <div className="relative z-20 grid gap-6 rounded-md border border-brand bg-popover p-4 text-popover-foreground shadow-md">
         <Link href="/" className="flex items-center space-x-2">
           <Icons.logo />
           <span className="font-bold">{siteConfig.name}</span>
         </Link>
-        <nav className="grid grid-flow-row auto-rows-max text-sm">
+        <nav className="grid grid-flow-row auto-rows-max border-brand text-sm">
           {items.map((item, index) => (
             <Link
               key={index}
               href={item.disabled ? '#' : item.href}
               className={cn(
                 'flex w-full items-center rounded-md p-2 text-sm font-medium hover:underline',
+                pathname.startsWith(item.href)
+                  ? 'font-semibold text-brand underline decoration-4 underline-offset-4'
+                  : 'text-muted-foreground',
                 item.disabled && 'cursor-not-allowed opacity-60',
               )}
             >

--- a/app/components/layout/nav.tsx
+++ b/app/components/layout/nav.tsx
@@ -27,8 +27,10 @@ export function DashboardNav({ items }: DashboardNavProps) {
             <Link key={index} href={item.disabled ? '/' : item.href}>
               <span
                 className={cn(
-                  'group flex items-center rounded-md px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground',
-                  path === item.href ? 'bg-brand/20' : 'transparent',
+                  'group flex items-center rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-brand/20 hover:text-foreground',
+                  path === item.href
+                    ? 'bg-brand/20 text-foreground'
+                    : 'transparent',
                   item.disabled && 'cursor-not-allowed opacity-80',
                 )}
               >

--- a/app/config/admin.ts
+++ b/app/config/admin.ts
@@ -13,11 +13,6 @@ export const adminConfig: AdminConfig = {
       isTeacher: true,
     },
     {
-      title: 'Community',
-      href: 'https://discord.com/channels/1151749282806910976/1154115151407091862',
-      isExternal: true,
-    },
-    {
       title: 'Playbooks',
       href: '/learn',
     },
@@ -36,7 +31,7 @@ export const adminConfig: AdminConfig = {
     {
       title: 'Admin home',
       href: '/admin',
-      icon: 'gauge',
+      icon: 'home',
     },
     {
       title: 'AI center',

--- a/app/config/dashboard.ts
+++ b/app/config/dashboard.ts
@@ -13,11 +13,6 @@ export const dashboardConfig: DashboardConfig = {
       isTeacher: true,
     },
     {
-      title: 'Community',
-      href: 'https://discord.com/channels/1151749282806910976/1154115151407091862',
-      isExternal: true,
-    },
-    {
       title: 'Playbooks',
       href: '/learn',
     },
@@ -34,9 +29,9 @@ export const dashboardConfig: DashboardConfig = {
   ],
   sidebarNav: [
     {
-      title: 'Dashboard',
+      title: 'Home',
       href: '/dashboard',
-      icon: 'dashboard',
+      icon: 'home',
     },
     {
       title: 'Billing',

--- a/app/config/docs.ts
+++ b/app/config/docs.ts
@@ -3,6 +3,25 @@ import { DocsConfig } from '@/app/lib/types';
 export const docsConfig: DocsConfig = {
   mainNav: [
     {
+      title: 'Dashboard',
+      href: '/dashboard',
+      isLoggedIn: true,
+    },
+    {
+      title: 'Admin',
+      href: '/admin',
+      isTeacher: true,
+    },
+    {
+      title: 'Playbooks',
+      href: '/learn',
+    },
+    {
+      title: 'Tools',
+      href: '/tools',
+      disabled: true,
+    },
+    {
       title: 'Insights',
       href: '/docs',
       disabled: true,

--- a/app/config/playbook.ts
+++ b/app/config/playbook.ts
@@ -13,11 +13,6 @@ export const playbookConfig: PlaybookConfig = {
       isTeacher: true,
     },
     {
-      title: 'Community',
-      href: 'https://discord.com/channels/1151749282806910976/1154115151407091862',
-      isExternal: true,
-    },
-    {
       title: 'Playbooks',
       href: '/learn',
     },

--- a/app/config/playbooks.ts
+++ b/app/config/playbooks.ts
@@ -13,11 +13,6 @@ export const playbooksConfig: PlaybooksConfig = {
       isTeacher: true,
     },
     {
-      title: 'Community',
-      href: 'https://discord.com/channels/1151749282806910976/1154115151407091862',
-      isExternal: true,
-    },
-    {
       title: 'Playbooks',
       href: '/learn',
     },

--- a/app/config/teacher.ts
+++ b/app/config/teacher.ts
@@ -13,11 +13,6 @@ export const teacherConfig: TeacherConfig = {
       isTeacher: true,
     },
     {
-      title: 'Community',
-      href: 'https://discord.com/channels/1151749282806910976/1154115151407091862',
-      isExternal: true,
-    },
-    {
       title: 'Playbooks',
       href: '/learn',
     },
@@ -36,7 +31,7 @@ export const teacherConfig: TeacherConfig = {
     {
       title: 'Admin home',
       href: '/admin',
-      icon: 'gauge',
+      icon: 'home',
     },
     {
       title: 'Playbooks admin',

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: Documentation
-description: Welcome to the Taxonomy documentation.
+title: Insights
+description: Welcome to the future home of And Voila Insights.
 ---
 
-This is the documentation for the Taxonomy site.
+All this content is placeholder.
 
 This is an example of a doc site built using [ContentLayer](/docs/documentation/contentlayer) and MDX.
 


### PR DESCRIPTION
- refined mobile-nav styles
  - switched to client component for active state
- added mobile sidebar child where needed
- removed community link in main-nav
- changed the redundant label to home and the icon too
- updated title and intro of mock index on insights

Closes #72