### PR TITLE
fix: table of contents formatting #551

### DIFF
--- a/src/app/(routes)/studio/(teams)/[team_slug]/workspace/layout.tsx
+++ b/src/app/(routes)/studio/(teams)/[team_slug]/workspace/layout.tsx
@@ -39,9 +39,7 @@ export default async function WorkspaceSharedLayout({
       <NavBar user={user} teams={teams} activeTeamSlug={params.team_slug} />
       <div className="flex flex-1 flex-col ps-16 pt-16">
         <Sidebar links={links} />
-        <main className="flex w-full flex-1 flex-col overflow-hidden">
-          {children}
-        </main>
+        <main className="flex w-full flex-1 flex-col">{children}</main>
       </div>
       <SiteFooter />
     </div>

--- a/src/components/providers/top-loader.tsx
+++ b/src/components/providers/top-loader.tsx
@@ -1,27 +1,20 @@
 'use client';
 
-import { useTheme } from 'next-themes';
 import NextTopLoader from 'nextjs-toploader';
 
-const TopLoader = () => {
-  const { theme } = useTheme();
-  const color = theme === 'dark' ? '#a6fd29' : '#5aa300';
-
-  return (
-    <NextTopLoader
-      color={color}
-      initialPosition={0.08}
-      crawlSpeed={30}
-      height={6}
-      crawl={true}
-      showSpinner={false}
-      easing="ease"
-      speed={200}
-      shadow={`0 0 10px ${color}, 0 0 5px ${color}`}
-      zIndex={1600}
-      showAtBottom={false}
-    />
-  );
-};
-
+const TopLoader = () => (
+  <NextTopLoader
+    color="#87F500"
+    initialPosition={0.08}
+    crawlSpeed={30}
+    height={6}
+    crawl={true}
+    showSpinner={false}
+    easing="ease"
+    speed={200}
+    shadow="0 0 10px #87F500,0 0 5px #87F500"
+    zIndex={1600}
+    showAtBottom={false}
+  />
+);
 export default TopLoader;


### PR DESCRIPTION
- unable to duplicate issues with TOC at this time 
- closes #551

- removed overflow hidden from layout so the widget would stick
- revert top loader theme and added a deeper green so we know it's loading on top